### PR TITLE
feat: ID 변경 api 추가

### DIFF
--- a/server/src/main/java/com/danram/server/config/SecurityConfig.java
+++ b/server/src/main/java/com/danram/server/config/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
                 .authorizeRequests()
                 .antMatchers("/member/info").hasAnyAuthority("ROLE_USER", "ROLE_ADMIN")
                 .antMatchers("/member/info/**").hasAnyAuthority("ROLE_ADMIN")
+                .antMatchers("/member/change/**").hasAnyAuthority("ROLE_ADMIN")
                 .and().build();
     }
 }

--- a/server/src/main/java/com/danram/server/controller/MemberController.java
+++ b/server/src/main/java/com/danram/server/controller/MemberController.java
@@ -31,4 +31,9 @@ public class MemberController {
     public ResponseEntity<Member> getUserInfo(@PathVariable String username) {
         return ResponseEntity.ok(googleLoginService.getUserWithAuthorities(username).get());
     }
+
+    @GetMapping("/change/{id}")
+    public Long changeId(@RequestParam(name = "id") Long id) {
+        return googleLoginService.setId(id);
+    }
 }

--- a/server/src/main/java/com/danram/server/service/oauth/GoogleLoginService.java
+++ b/server/src/main/java/com/danram/server/service/oauth/GoogleLoginService.java
@@ -12,4 +12,5 @@ public interface GoogleLoginService {
     public Member signUp();
     public Optional<Member> getUserWithAuthorities();
     public Optional<Member> getUserWithAuthorities(String name);
+    public Long setId(Long id);
 }

--- a/server/src/main/java/com/danram/server/service/oauth/GoogleLoginServiceImpl.java
+++ b/server/src/main/java/com/danram/server/service/oauth/GoogleLoginServiceImpl.java
@@ -9,6 +9,7 @@ import com.danram.server.repository.MemberNameRepository;
 import com.danram.server.repository.TokensRepository;
 import com.danram.server.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GoogleLoginServiceImpl implements GoogleLoginService {
@@ -68,5 +70,14 @@ public class GoogleLoginServiceImpl implements GoogleLoginService {
     @Transactional(readOnly = true)
     public Optional<Member> getUserWithAuthorities(String name) {
         return memberRepository.findOneWithAuthoritiesByName(name);
+    }
+
+    @Override
+    public Long setId(final Long id) {
+        ID = id;
+
+        log.info(">> ID: {}", ID);
+
+        return ID;
     }
 }


### PR DESCRIPTION
GoogleLogInService의 signUp에서 아이디 값에 따라 MemberName의 값이 정해지는데 고정이라 문제가 있었습니다.
그래서 이 값을 api로 바꿀 수 있게 추가했습니다.