### PR TITLE
refactor: member id 변경 방식 변경

### DIFF
--- a/server/src/main/java/com/danram/server/domain/member/Member.java
+++ b/server/src/main/java/com/danram/server/domain/member/Member.java
@@ -18,7 +18,6 @@ import java.util.List;
 public class Member {
     @Id
     @Column(name = "user_id", columnDefinition = "int")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @ApiModelProperty(example = "고유 식별 ID")
     private Long userId;
 


### PR DESCRIPTION
# 변경 사항
- generatedvalue annotation 삭제
# 변경 이유
- spring에서 생성하는 id값과 auto increasement 값이 충돌하는 현상 때문에 변경